### PR TITLE
Font sizing bug in Safari

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -123,7 +123,12 @@ html {
   color: hsl(var(--text));
   color-scheme: light dark;
   font-family: var(--font-body);
+}
+
+body {
   font-size: 93.75%;
+  margin: 0 auto;
+  max-inline-size: 90rem;
 
   @media (min-width: 40rem) {
     font-size: 100%;
@@ -136,11 +141,6 @@ html {
   @media (min-width: 72rem) {
     font-size: 112.5%;
   }
-}
-
-body {
-  margin: 0 auto;
-  max-inline-size: 90rem;
 }
 
 main {


### PR DESCRIPTION
Target the `body` element instead of the `html` element with font-size declarations. Prevents Safari from using updated font size when calculating rems.

Bug report: https://bugs.webkit.org/show_bug.cgi?id=156684

My reproduction: https://codesandbox.io/s/gallant-austin-kh4qf?file=/index.html
